### PR TITLE
Allow incorrect letters to be re-used.

### DIFF
--- a/lib/home.dart
+++ b/lib/home.dart
@@ -743,7 +743,7 @@ class _HomePageState extends State<HomePage> {
               else {
                 if(val.character != null) {
                   // check if the character is not disable
-                  if (_checkButton(val.character!.toUpperCase())) {
+                  // if (_checkButton(val.character!.toUpperCase())) {
                     // check if the current guess length < than max length
                     if(_guess.length < _maxLength) {
                       // debugPrint(value);
@@ -756,7 +756,7 @@ class _HomePageState extends State<HomePage> {
                     }
                   }
                 }
-              }
+              // }
             }),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/widgets/keyboard_button.dart
+++ b/lib/widgets/keyboard_button.dart
@@ -38,9 +38,10 @@ class KeyboardButton extends StatelessWidget {
       height: 50,
       child: InkWell(
         onTap: (() {
-          if(enabled > 0) {
-            onPress(char);
-          }
+          // if(enabled > 0) {
+          onPress(char);
+      
+          // }
         }),
         child: Container(
           decoration: BoxDecoration(


### PR DESCRIPTION
The original wordle allows this, and is a critical part of strategy for those willing to nuke a guess to narrow down letters with other words. 